### PR TITLE
Add user creation form and backend support

### DIFF
--- a/backend/insert-admin.js
+++ b/backend/insert-admin.js
@@ -10,6 +10,7 @@ mongoose.connect('mongodb://localhost:27017/local', {
 
 // Definir el esquema
 const userSchema = new mongoose.Schema({
+  nombre: String,
   usuario: String,
   correo: String,
   clave: String,
@@ -33,6 +34,7 @@ async function crearAdmin() {
     const hash = await bcrypt.hash('1234', 10);
 
     const nuevoUsuario = new User({
+      nombre: 'Administrador',
       usuario: 'admin1',
       correo: 'admin@ejemplo1.com',
       clave: hash,

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema({
+  nombre: String,
   usuario: String,
   correo: String,
   clave: String,

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -31,6 +31,7 @@ router.post('/login', async (req, res) => {
     res.json({
       mensaje: 'Login exitoso',
       usuario: {
+        nombre: user.nombre,
         usuario: user.usuario,
         correo: user.correo,
         rol: user.rol,
@@ -44,7 +45,7 @@ router.post('/login', async (req, res) => {
 });
 
 router.post('/register', async (req, res) => {
-  const { usuario, correo, clave, rol } = req.body;
+  const { nombre, usuario, correo, clave, rol } = req.body;
 
   try {
     // Verifica si el usuario ya existe
@@ -58,6 +59,7 @@ router.post('/register', async (req, res) => {
 
     // Crear nuevo usuario
     const nuevoUsuario = new User({
+      nombre,
       usuario,
       correo,
       clave: claveHasheada,

--- a/frontend/src/app/pages/users/users.component.html
+++ b/frontend/src/app/pages/users/users.component.html
@@ -13,7 +13,49 @@
         label="Agregar Usuario"
         icon="pi pi-plus"
         class="add-user-btn"
+        (click)="toggleForm()"
       ></button>
+    </div>
+
+    <div class="add-form" *ngIf="showForm">
+      <form (ngSubmit)="addUser()" #userForm="ngForm">
+        <input
+          type="text"
+          placeholder="Nombre"
+          name="nombre"
+          [(ngModel)]="newUser.nombre"
+          required
+        />
+        <input
+          type="text"
+          placeholder="Usuario"
+          name="usuario"
+          [(ngModel)]="newUser.usuario"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          name="clave"
+          [(ngModel)]="newUser.clave"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          name="correo"
+          [(ngModel)]="newUser.correo"
+          required
+        />
+        <input
+          type="text"
+          placeholder="Rol"
+          name="rol"
+          [(ngModel)]="newUser.rol"
+          required
+        />
+        <button pButton type="submit" label="Guardar" [disabled]="userForm.invalid"></button>
+      </form>
     </div>
 
     <p-table

--- a/frontend/src/app/pages/users/users.component.scss
+++ b/frontend/src/app/pages/users/users.component.scss
@@ -45,6 +45,18 @@ background: linear-gradient(135deg, #000000 0%, #360907 100%);
     }
   }
 }
+
+.add-form {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+
+  input {
+    padding: 0.5rem;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+  }
+}
 .p-table .p-datatable-thead > tr > th {
   background-color: #e0f7fa;
   color: #004d40;

--- a/frontend/src/app/pages/users/users.component.ts
+++ b/frontend/src/app/pages/users/users.component.ts
@@ -1,46 +1,78 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { UsersService, NewUser } from '../../services/users.service';
 
 @Component({
   standalone: true,
   selector: 'app-users',
-  imports: [CommonModule, TableModule, ButtonModule],
+  imports: [CommonModule, FormsModule, TableModule, ButtonModule, InputTextModule, PasswordModule],
   templateUrl: './users.component.html',
   styleUrls: ['./users.component.scss']
 })
 export class UsersComponent {
-users = [
-  {
-    id: 1,
-    name: 'Juan Pérez',
-    email: 'juan@example.com',
-    role: 'Admin',
-    username: 'juanp',
-    status: 'Activo',
-    createdAt: '2024-01-01',
-    lastLogin: '2024-05-25 10:30'
-  },
-  {
-    id: 2,
-    name: 'María Gómez',
-    email: 'maria@example.com',
-    role: 'Usuario',
-    username: 'mariag',
-    status: 'Activo',
-    createdAt: '2024-02-12',
-    lastLogin: '2024-05-24 09:45'
-  },
-  {
-    id: 3,
-    name: 'Carlos Ruiz',
-    email: 'carlos@example.com',
-    role: 'Usuario',
-    username: 'cruiz',
-    status: 'Inactivo',
-    createdAt: '2024-03-01',
-    lastLogin: '2024-05-10 14:15'
+  showForm = false;
+  newUser: NewUser = { nombre: '', usuario: '', clave: '', correo: '', rol: '' };
+
+  constructor(private usersService: UsersService) {}
+
+  users = [
+    {
+      id: 1,
+      name: 'Juan Pérez',
+      email: 'juan@example.com',
+      role: 'Admin',
+      username: 'juanp',
+      status: 'Activo',
+      createdAt: '2024-01-01',
+      lastLogin: '2024-05-25 10:30'
+    },
+    {
+      id: 2,
+      name: 'María Gómez',
+      email: 'maria@example.com',
+      role: 'Usuario',
+      username: 'mariag',
+      status: 'Activo',
+      createdAt: '2024-02-12',
+      lastLogin: '2024-05-24 09:45'
+    },
+    {
+      id: 3,
+      name: 'Carlos Ruiz',
+      email: 'carlos@example.com',
+      role: 'Usuario',
+      username: 'cruiz',
+      status: 'Inactivo',
+      createdAt: '2024-03-01',
+      lastLogin: '2024-05-10 14:15'
+    }
+  ];
+
+  toggleForm() {
+    this.showForm = !this.showForm;
+    if (this.showForm) {
+      this.newUser = { nombre: '', usuario: '', clave: '', correo: '', rol: '' };
+    }
   }
-];
+
+  addUser() {
+    this.usersService.register(this.newUser).subscribe(() => {
+      this.showForm = false;
+      this.users.push({
+        id: this.users.length + 1,
+        name: this.newUser.nombre,
+        email: this.newUser.correo,
+        role: this.newUser.rol,
+        username: this.newUser.usuario,
+        status: 'Activo',
+        createdAt: new Date().toISOString().split('T')[0],
+        lastLogin: ''
+      });
+    });
+  }
 }

--- a/frontend/src/app/services/users.service.ts
+++ b/frontend/src/app/services/users.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface NewUser {
+  nombre: string;
+  usuario: string;
+  clave: string;
+  correo: string;
+  rol: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private apiUrl = 'http://localhost:3000/users';
+
+  constructor(private http: HttpClient) {}
+
+  register(user: NewUser): Observable<any> {
+    return this.http.post(`${this.apiUrl}/register`, user);
+  }
+}


### PR DESCRIPTION
## Summary
- allow storing user name on the server
- expose name from login and handle in registration
- update admin seeding script for new field
- create `UsersService` on frontend to call registration endpoint
- extend users page with form for adding users

## Testing
- `npm test --silent` *(fails: Error: no test specified)*
- `npm test --silent` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5878314832f93d38e12b643f922