### PR TITLE
Add user listing via backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# miPrimerProyecto
+
+## Requisitos
+- Node.js 18+
+- MongoDB en `mongodb://localhost:27017/local`
+
+## Instalación
+
+### Backend
+```bash
+cd backend
+npm install
+npm start
+```
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm start
+```
+
+El frontend se sirve en `http://localhost:4200` y espera que el backend esté en `http://localhost:3000`.

--- a/backend/index.js
+++ b/backend/index.js
@@ -20,7 +20,11 @@ mongoose.connect('mongodb://localhost:27017/local', {
 // Rutas
 app.use('/users', usersRouter);
 
-// Inicio del servidor
-app.listen(PORT, () => {
-  console.log(`Servidor backend corriendo en http://localhost:${PORT}`);
-});
+// Inicio del servidor solo si se ejecuta directamente
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Servidor backend corriendo en http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/backend/insert-admin.js
+++ b/backend/insert-admin.js
@@ -10,6 +10,7 @@ mongoose.connect('mongodb://localhost:27017/local', {
 
 // Definir el esquema
 const userSchema = new mongoose.Schema({
+  nombre: String,
   usuario: String,
   correo: String,
   clave: String,
@@ -33,6 +34,7 @@ async function crearAdmin() {
     const hash = await bcrypt.hash('1234', 10);
 
     const nuevoUsuario = new User({
+      nombre: 'Administrador',
       usuario: 'admin1',
       correo: 'admin@ejemplo1.com',
       clave: hash,

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema({
+  nombre: String,
   usuario: String,
   correo: String,
   clave: String,

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "keywords": [],
   "author": "",

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -8,6 +8,17 @@ router.get('/test', (req, res) => {
   res.json({ message: 'Ruta /users/test funcionando correctamente' });
 });
 
+// Obtener todos los usuarios
+router.get('/', async (req, res) => {
+  try {
+    const usuarios = await User.find({}, '-clave');
+    res.json(usuarios);
+  } catch (err) {
+    console.error('Error al obtener usuarios:', err);
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
 // Ruta de login
 router.post('/login', async (req, res) => {
   const { usuario, clave } = req.body;
@@ -31,6 +42,7 @@ router.post('/login', async (req, res) => {
     res.json({
       mensaje: 'Login exitoso',
       usuario: {
+        nombre: user.nombre,
         usuario: user.usuario,
         correo: user.correo,
         rol: user.rol,
@@ -44,7 +56,7 @@ router.post('/login', async (req, res) => {
 });
 
 router.post('/register', async (req, res) => {
-  const { usuario, correo, clave, rol } = req.body;
+  const { nombre, usuario, correo, clave, rol } = req.body;
 
   try {
     // Verifica si el usuario ya existe
@@ -58,6 +70,7 @@ router.post('/register', async (req, res) => {
 
     // Crear nuevo usuario
     const nuevoUsuario = new User({
+      nombre,
       usuario,
       correo,
       clave: claveHasheada,

--- a/backend/users.test.js
+++ b/backend/users.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const app = require('./index');
+
+beforeAll(async () => {
+  await mongoose.connect('mongodb://localhost:27017/local', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+describe('POST /users/register', () => {
+  it('should create a user', async () => {
+    const res = await request(app).post('/users/register').send({
+      nombre: 'Test',
+      usuario: 'testuser',
+      correo: 't@example.com',
+      clave: '1234',
+      rol: 'usuario'
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe('GET /users', () => {
+  it('should return a list', async () => {
+    const res = await request(app).get('/users');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});

--- a/frontend/src/app/layout/layout.component.scss
+++ b/frontend/src/app/layout/layout.component.scss
@@ -75,6 +75,6 @@
   padding: 0;
   min-height: 100vh;
   color: white;
-  border: none
+  border: none;
 }
 

--- a/frontend/src/app/pages/users/users.component.html
+++ b/frontend/src/app/pages/users/users.component.html
@@ -13,7 +13,49 @@
         label="Agregar Usuario"
         icon="pi pi-plus"
         class="add-user-btn"
+        (click)="toggleForm()"
       ></button>
+    </div>
+
+    <div class="add-form" *ngIf="showForm">
+      <form (ngSubmit)="addUser()" #userForm="ngForm">
+        <input
+          type="text"
+          placeholder="Nombre"
+          name="nombre"
+          [(ngModel)]="newUser.nombre"
+          required
+        />
+        <input
+          type="text"
+          placeholder="Usuario"
+          name="usuario"
+          [(ngModel)]="newUser.usuario"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          name="clave"
+          [(ngModel)]="newUser.clave"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          name="correo"
+          [(ngModel)]="newUser.correo"
+          required
+        />
+        <input
+          type="text"
+          placeholder="Rol"
+          name="rol"
+          [(ngModel)]="newUser.rol"
+          required
+        />
+        <button pButton type="submit" label="Guardar" [disabled]="userForm.invalid"></button>
+      </form>
     </div>
 
     <p-table

--- a/frontend/src/app/pages/users/users.component.scss
+++ b/frontend/src/app/pages/users/users.component.scss
@@ -45,6 +45,18 @@ background: linear-gradient(135deg, #000000 0%, #360907 100%);
     }
   }
 }
+
+.add-form {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+
+  input {
+    padding: 0.5rem;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+  }
+}
 .p-table .p-datatable-thead > tr > th {
   background-color: #e0f7fa;
   color: #004d40;

--- a/frontend/src/app/pages/users/users.component.ts
+++ b/frontend/src/app/pages/users/users.component.ts
@@ -1,46 +1,57 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { UsersService, NewUser } from '../../services/users.service';
 
 @Component({
   standalone: true,
   selector: 'app-users',
-  imports: [CommonModule, TableModule, ButtonModule],
+  imports: [CommonModule, FormsModule, TableModule, ButtonModule, InputTextModule, PasswordModule],
   templateUrl: './users.component.html',
   styleUrls: ['./users.component.scss']
 })
-export class UsersComponent {
-users = [
-  {
-    id: 1,
-    name: 'Juan Pérez',
-    email: 'juan@example.com',
-    role: 'Admin',
-    username: 'juanp',
-    status: 'Activo',
-    createdAt: '2024-01-01',
-    lastLogin: '2024-05-25 10:30'
-  },
-  {
-    id: 2,
-    name: 'María Gómez',
-    email: 'maria@example.com',
-    role: 'Usuario',
-    username: 'mariag',
-    status: 'Activo',
-    createdAt: '2024-02-12',
-    lastLogin: '2024-05-24 09:45'
-  },
-  {
-    id: 3,
-    name: 'Carlos Ruiz',
-    email: 'carlos@example.com',
-    role: 'Usuario',
-    username: 'cruiz',
-    status: 'Inactivo',
-    createdAt: '2024-03-01',
-    lastLogin: '2024-05-10 14:15'
+export class UsersComponent implements OnInit {
+  showForm = false;
+  newUser: NewUser = { nombre: '', usuario: '', clave: '', correo: '', rol: '' };
+
+  users: any[] = [];
+
+  constructor(private usersService: UsersService) {}
+
+  ngOnInit() {
+    this.loadUsers();
   }
-];
+
+  private loadUsers() {
+    this.usersService.getUsers().subscribe((data) => {
+      this.users = data.map((u: any) => ({
+        id: u._id,
+        name: u.nombre,
+        username: u.usuario,
+        email: u.correo,
+        role: u.rol,
+        status: u.activo ? 'Activo' : 'Inactivo',
+        createdAt: u.fecha_creacion ? u.fecha_creacion.split('T')[0] : '',
+        lastLogin: ''
+      }));
+    });
+  }
+
+  toggleForm() {
+    this.showForm = !this.showForm;
+    if (this.showForm) {
+      this.newUser = { nombre: '', usuario: '', clave: '', correo: '', rol: '' };
+    }
+  }
+
+  addUser() {
+    this.usersService.register(this.newUser).subscribe(() => {
+      this.showForm = false;
+      this.loadUsers();
+    });
+  }
 }

--- a/frontend/src/app/services/users.service.spec.ts
+++ b/frontend/src/app/services/users.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { UsersService, NewUser } from './users.service';
+import { environment } from '../../environments/environment';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(UsersService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should post to register endpoint', () => {
+    const user: NewUser = { nombre: 'a', usuario: 'b', clave: 'c', correo: 'd', rol: 'e' };
+    service.register(user).subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/users/register`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(user);
+    req.flush({});
+  });
+
+  it('should get users', () => {
+    service.getUsers().subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/users`);
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+});

--- a/frontend/src/app/services/users.service.ts
+++ b/frontend/src/app/services/users.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface NewUser {
+  nombre: string;
+  usuario: string;
+  clave: string;
+  correo: string;
+  rol: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private apiUrl = `${environment.apiUrl}/users`;
+
+  constructor(private http: HttpClient) {}
+
+  register(user: NewUser): Observable<any> {
+    return this.http.post(`${this.apiUrl}/register`, user);
+  }
+
+  getUsers(): Observable<any[]> {
+    return this.http.get<any[]>(this.apiUrl);
+  }
+}

--- a/frontend/src/environments/environment.development.ts
+++ b/frontend/src/environments/environment.development.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};


### PR DESCRIPTION
## Summary
- expose `/users` route to list all users
- add `getUsers` method in frontend service
- load users from the API in the users component
- test backend and frontend changes

## Testing
- `npm test --silent` in `backend` *(fails: Mongo connection timeout)*
- `npm test --silent` in `frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5878314832f93d38e12b643f922