### PR TITLE
Add paginated users list

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -78,4 +78,34 @@ router.post('/register', async (req, res) => {
   }
 });
 
+// Obtener usuarios paginados
+router.get('/', async (req, res) => {
+  const page = parseInt(req.query.page) || 1;
+  const limit = parseInt(req.query.limit) || 50;
+
+  try {
+    const users = await User.find()
+      .skip((page - 1) * limit)
+      .limit(limit);
+
+    const formatted = users.map((u) => ({
+      id: u._id,
+      name: u.nombre,
+      username: u.usuario,
+      email: u.correo,
+      role: u.rol,
+      status: u.activo ? 'Activo' : 'Inactivo',
+      createdAt: u.fecha_creacion
+        ? u.fecha_creacion.toISOString().split('T')[0]
+        : '',
+      lastLogin: ''
+    }));
+
+    res.json({ users: formatted });
+  } catch (err) {
+    console.error('Error al obtener usuarios:', err);
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
 module.exports = router;

--- a/backend/users.test.js
+++ b/backend/users.test.js
@@ -22,3 +22,11 @@ describe('POST /users/register', () => {
     expect(res.statusCode).toBe(201);
   });
 });
+
+describe('GET /users', () => {
+  it('should return users list', async () => {
+    const res = await request(app).get('/users');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body.users)).toBe(true);
+  });
+});

--- a/frontend/src/app/pages/users/users.component.html
+++ b/frontend/src/app/pages/users/users.component.html
@@ -61,7 +61,7 @@
     <p-table
       [value]="users"
       [paginator]="true"
-      [rows]="5"
+      [rows]="50"
       [scrollable]="true"
       scrollHeight="flex"
       class="p-table"

--- a/frontend/src/app/pages/users/users.component.ts
+++ b/frontend/src/app/pages/users/users.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
@@ -14,44 +14,23 @@ import { UsersService, NewUser } from '../../services/users.service';
   templateUrl: './users.component.html',
   styleUrls: ['./users.component.scss']
 })
-export class UsersComponent {
+export class UsersComponent implements OnInit {
   showForm = false;
   newUser: NewUser = { nombre: '', usuario: '', clave: '', correo: '', rol: '' };
 
   constructor(private usersService: UsersService) {}
 
-  users = [
-    {
-      id: 1,
-      name: 'Juan Pérez',
-      email: 'juan@example.com',
-      role: 'Admin',
-      username: 'juanp',
-      status: 'Activo',
-      createdAt: '2024-01-01',
-      lastLogin: '2024-05-25 10:30'
-    },
-    {
-      id: 2,
-      name: 'María Gómez',
-      email: 'maria@example.com',
-      role: 'Usuario',
-      username: 'mariag',
-      status: 'Activo',
-      createdAt: '2024-02-12',
-      lastLogin: '2024-05-24 09:45'
-    },
-    {
-      id: 3,
-      name: 'Carlos Ruiz',
-      email: 'carlos@example.com',
-      role: 'Usuario',
-      username: 'cruiz',
-      status: 'Inactivo',
-      createdAt: '2024-03-01',
-      lastLogin: '2024-05-10 14:15'
-    }
-  ];
+  users: any[] = [];
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  loadUsers(page: number = 1) {
+    this.usersService.getUsers(page).subscribe((res) => {
+      this.users = res.users;
+    });
+  }
 
   toggleForm() {
     this.showForm = !this.showForm;

--- a/frontend/src/app/services/users.service.ts
+++ b/frontend/src/app/services/users.service.ts
@@ -20,4 +20,8 @@ export class UsersService {
   register(user: NewUser): Observable<any> {
     return this.http.post(`${this.apiUrl}/register`, user);
   }
+
+  getUsers(page: number = 1): Observable<any> {
+    return this.http.get(`${this.apiUrl}?page=${page}&limit=50`);
+  }
 }


### PR DESCRIPTION
## Summary
- implement GET /users for paginated query
- expose user list from Angular service
- load users from backend in users page
- display 50 users per page
- test for new endpoint

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842374606f8832fad45f97151e5ea2e